### PR TITLE
chore:: add nullptr check

### DIFF
--- a/src/ConsoleAppender.cpp
+++ b/src/ConsoleAppender.cpp
@@ -86,7 +86,9 @@ void ConsoleAppender::append(const QDateTime &time, Logger::LogLevel level, cons
                              const char *func, const QString &category, const QString &msg)
 {
     auto clogger = spdlog::get("console");
-    Q_ASSERT(clogger);
+    if (Q_UNLIKELY(!clogger))
+        return;
+
     clogger->set_level(spdlog::level::level_enum(detailsLevel()));
 
     const auto &formatted = formattedString(time, level, file, line, func, category, msg, isatty(STDOUT_FILENO));

--- a/src/FileAppender.cpp
+++ b/src/FileAppender.cpp
@@ -125,6 +125,8 @@ void FileAppender::append(const QDateTime &time, Logger::LogLevel level, const c
         return;
 
     auto fl = spdlog::get(loggerName(m_logFile));
+    if (Q_UNLIKELY(!fl))
+        return;
     fl->set_level(spdlog::level::level_enum(detailsLevel()));
 
     const auto &formatted = formattedString(time, level, file, line, func, category, msg);


### PR DESCRIPTION
app may crash when printing logs on exit