### PR TITLE
fix: make version parameter optional in release workflow

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string


### PR DESCRIPTION
Changed the version parameter from required to optional in the GitHub
Actions workflow. This provides more flexibility when triggering
releases, allowing the workflow to be run without specifying a version
(which might be determined programmatically later in the workflow).

This modification helps accommodate cases where:
1. The version might be calculated dynamically in later steps
2. We want to trigger the workflow for testing purposes without a
specific version
3. Default versioning behavior needs to be implemented

fix: 在发布工作流中将版本参数设为可选

修改了 GitHub Actions 工作流中的版本参数，从必填改为可选。这为触发发布提
供了更大的灵活性，允许在不指定版本的情况下运行工作流（版本可能在后续工作
流步骤中以编程方式确定）。

此修改有助于适应以下情况：
1. 版本可能在后续步骤中动态计算
2. 我们希望在测试时无需指定特定版本即可触发工作流
3. 需要实现默认版本控制行为
