### PR TITLE
fix: update library dependency version format

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,4 +31,4 @@ override_dh_auto_configure:
 	dh_auto_configure -- -DDLOG_VERSION=$(PACK_VER) -DBUILD_WITH_SYSTEMD=ON -DBUILD_WITH_QT6=ON
 
 override_dh_makeshlibs:
-	dh_makeshlibs -V "libdtk6log (>= $(shell echo $(VERSION) | cut -d '.' -f 1,2))"
+	dh_makeshlibs -V "libdtk6log (>= $(shell echo $(VERSION) | cut -d '.' -f 1,2,3))"


### PR DESCRIPTION
Changed the version pattern in dh_makeshlibs from major.minor to
major.minor.patch
Previously used cut command only extracted first two version components
Now extracts all three components (major.minor.patch) for proper version
matching
This ensures correct library dependency resolution in Debian packaging
system

fix: 更新库依赖版本格式

将 dh_makeshlibs 中的版本模式从主版本.次版本改为主版本.次版本.修订版本
之前使用的 cut 命令仅提取前两个版本组件
现在提取所有三个组件（主版本.次版本.修订版本）以实现正确的版本匹配
确保在 Debian 打包系统中正确的库依赖解析
